### PR TITLE
Update

### DIFF
--- a/src/components/GuessForm/GuessForm.jsx
+++ b/src/components/GuessForm/GuessForm.jsx
@@ -123,7 +123,7 @@ const GuessForm = ({
         url.searchParams.set("language", "en-US");
         url.searchParams.set("page", "1");
         url.searchParams.set("with_text_query", query);
-        url.searchParams.set("sort_by", "revenue.desc");
+        url.searchParams.set("sort_by", "popularity.desc");
         url.searchParams.set("with_runtime.gte", String(MIN_RUNTIME_MINUTES));
         url.searchParams.set("without_genres", EXCLUDED_GENRES.join("|"));
 


### PR DESCRIPTION
This pull request updates the movie search sorting logic in the `GuessForm` component. The API query now sorts results by popularity instead of revenue, which should improve the relevance of search results for users.

* Changed the `sort_by` parameter from `"revenue.desc"` to `"popularity.desc"` in the movie API query within `src/components/GuessForm/GuessForm.jsx`.