### PR TITLE
Remove Year from Guess Form

### DIFF
--- a/src/components/GuessForm/GuessForm.jsx
+++ b/src/components/GuessForm/GuessForm.jsx
@@ -273,12 +273,7 @@ const GuessForm = ({
                           data-movie-id={movie.id}
                           onClick={handleSuggestionSelect}
                         >
-                          {movie.title} (
-                          {formatDate(
-                            movie.release_date,
-                            YEAR_ONLY_DATE_OPTIONS
-                          )}
-                          )
+                          {movie.title}
                         </button>
                       </li>
                     );


### PR DESCRIPTION
This pull request makes a small adjustment to the display of movie suggestions in the `GuessForm` component by removing the release year from the suggestion text. Now, only the movie title is shown for each suggestion.

- Removed the display of the movie release year from each suggestion in the `GuessForm` component, so only the movie title is shown.

Closes #19 