### PR TITLE
fix: resolve useFetch loading state when url is falsy

### DIFF
--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -18,6 +18,7 @@ const useFetch = (url, options = {}) => {
 
   useEffect(() => {
     if (!url) {
+      setState({ data: null, isLoading: false });
       return;
     }
 

--- a/src/hooks/useFetch.test.js
+++ b/src/hooks/useFetch.test.js
@@ -16,11 +16,11 @@ describe("useFetch", () => {
     axios.isCancel.mockReturnValue(false);
   });
 
-  test("does not fetch when url is falsy", () => {
+  test("does not fetch and resolves to not-loading when url is falsy", () => {
     const { result } = renderHook(() => useFetch(""));
 
     expect(axios.get).not.toHaveBeenCalled();
-    expect(result.current).toEqual({ data: null, isLoading: true });
+    expect(result.current).toEqual({ data: null, isLoading: false });
   });
 
   test("returns response.data and clears loading on success", async () => {

--- a/src/hooks/usePuzzleData.test.js
+++ b/src/hooks/usePuzzleData.test.js
@@ -15,11 +15,11 @@ describe("usePuzzleData", () => {
     axios.isCancel.mockReturnValue(false);
   });
 
-  test("does not fetch when apiUrl is missing", () => {
+  test("does not fetch and resolves to not-loading when apiUrl is missing", () => {
     const { result } = renderHook(() => usePuzzleData("", "123"));
 
     expect(axios.get).not.toHaveBeenCalled();
-    expect(result.current).toEqual({ data: null, isLoading: true });
+    expect(result.current).toEqual({ data: null, isLoading: false });
   });
 
   test("fetches latest puzzle when puzzleId is omitted", async () => {

--- a/src/hooks/usePuzzleList.test.js
+++ b/src/hooks/usePuzzleList.test.js
@@ -15,11 +15,11 @@ describe("usePuzzleList", () => {
     axios.isCancel.mockReturnValue(false);
   });
 
-  test("does not fetch when apiUrl is missing", () => {
+  test("does not fetch and resolves to not-loading when apiUrl is missing", () => {
     const { result } = renderHook(() => usePuzzleList(""));
 
     expect(axios.get).not.toHaveBeenCalled();
-    expect(result.current).toEqual({ data: null, isLoading: true });
+    expect(result.current).toEqual({ data: null, isLoading: false });
   });
 
   test("fetches and normalizes puzzles array", async () => {


### PR DESCRIPTION
Addresses code-review feedback on #44.

`useFetch` initialised `isLoading: true` and the effect early-returned on a falsy `url` without updating state — leaving consumers stuck on a permanent loading flag whenever the URL was gated off (missing API base URL or TMDB token). Now resets to `{ data: null, isLoading: false }` in that branch.

Also updates the `useFetch` / `usePuzzleData` / `usePuzzleList` tests that had codified the old stuck-loading behaviour to assert the corrected contract.

The intentional `select`/`headers`-via-ref design (the other review note) is left as-is — adding them to the effect dep array would reintroduce the re-fetch churn that pattern deliberately avoids.

Full suite green: 30 suites / 100 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)